### PR TITLE
[0.1.1] Resolve issue with binary encoding of context

### DIFF
--- a/stacs/__about__.py
+++ b/stacs/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs"
 __summary__ = "Static Token And Credential Scanner."
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs/"
 __license__ = "BSD-3-Clause"

--- a/stacs/output/sarif.py
+++ b/stacs/output/sarif.py
@@ -117,11 +117,15 @@ def render(
             artifact_content["binary"] = finding.sample.finding
             # Unencode and then re-encode the sample into a single B64 string to provide
             # context.
-            context_content["binary"] = base64.b64encode(
-                base64.b64decode(finding.sample.before)
-                + base64.b64decode(finding.sample.finding)
-                + base64.b64decode(finding.sample.after)
+            context_content["binary"] = str(
+                base64.b64encode(
+                    base64.b64decode(finding.sample.before)
+                    + base64.b64decode(finding.sample.finding)
+                    + base64.b64decode(finding.sample.after)
+                ),
+                "utf-8",
             )
+            print(context_content["binary"])
         else:
             artifact_content["text"] = finding.sample.finding
             context_content["text"] = (


### PR DESCRIPTION
## Overview

An issue crept in with the addition of the context to SARIF output. This PR resolves by ensuring data is properly encoded to `str`.

