### PR TITLE
[0.3.2] Fix ignore list 'module' default

### DIFF
--- a/stacs/scan/__about__.py
+++ b/stacs/scan/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs"
 __summary__ = "Static Token And Credential Scanner."
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs/"
 __license__ = "BSD-3-Clause"

--- a/stacs/scan/model/ignore_list.py
+++ b/stacs/scan/model/ignore_list.py
@@ -30,7 +30,7 @@ class Entry(BaseModel, extra=Extra.forbid):
         title="The MD5 sum of the file to ignore.",
     )
     module: str = Field(
-        "rules",
+        "stacs.scan.scanner.rules",
         title="Which module to ignore findings from.",
     )
     references: List[str] = Field(

--- a/tests/test_filter_ignore_list.py
+++ b/tests/test_filter_ignore_list.py
@@ -29,7 +29,7 @@ class STACSFilterIgnoreListTestCase(unittest.TestCase):
                 offset=300,
             ),
             source=stacs.scan.model.finding.Source(
-                module="rules",
+                module="stacs.scan.scanner.rules",
                 reference="SomeRule",
             ),
         )
@@ -76,7 +76,7 @@ class STACSFilterIgnoreListTestCase(unittest.TestCase):
                 offset=300,
             ),
             source=stacs.scan.model.finding.Source(
-                module="rules",
+                module="stacs.scan.scanner.rules",
                 reference="SomeRule",
             ),
         )
@@ -125,7 +125,7 @@ class STACSFilterIgnoreListTestCase(unittest.TestCase):
                 offset=300,
             ),
             source=stacs.scan.model.finding.Source(
-                module="rules",
+                module="stacs.scan.scanner.rules",
                 reference="SomeRule",
             ),
         )


### PR DESCRIPTION
## Overview

### 🛠️ **New Features**
* N/A

### 🍩 **Improvements**
* N/A

### 🐛 **Bug Fixes**
* Ensure ignore-lists without a `module` specified default to a fully qualified module (`stacs.scan.scanner.rules`).