### PR TITLE
[0.4.2] Swap libarchive wrapper for compatibility.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
 click
 yara-python
 pydantic
-libarchive
+python-libarchive

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,9 @@
 #
 click==8.0.1
     # via -r requirements.in
-libarchive==0.4.7
-    # via -r requirements.in
-nose==1.3.7
-    # via libarchive
 pydantic==1.8.2
+    # via -r requirements.in
+python-libarchive==4.0.1.post1
     # via -r requirements.in
 typing-extensions==3.10.0.0
     # via pydantic

--- a/stacs/scan/__about__.py
+++ b/stacs/scan/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs"
 __summary__ = "Static Token And Credential Scanner."
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs/"
 __license__ = "BSD-3-Clause"


### PR DESCRIPTION
## Overview

This commit moves to using a different libarchive wrapper in order to improve compatibility, due to an unresolved issue with the currently used wrapper.

### 🛠️ **New Features**
* N/A

### 🍩 **Improvements**
* Move to `python-libarchive` from `libarchive` for [better cross distribution compatibility](https://github.com/dsoprea//PyEasyArchive/issues/50).
    * This is mostly a work around, so it may be swapped in future, but this should be a transparent change.

### 🐛 **Bug Fixes**

* N/A