### PR TITLE
[0.4.3] Allow continuation on archive errors. More debug.

### DIFF
--- a/stacs/scan/__about__.py
+++ b/stacs/scan/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs"
 __summary__ = "Static Token And Credential Scanner."
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs/"
 __license__ = "BSD-3-Clause"


### PR DESCRIPTION
## Overview

This pull-request allows the user to continue processing data when an archive is unable to be extracted. This is useful in cases where a single archive may be corrupt as part of a large run.

This change has been added to resolve issue #12.

### 🛠️ **New Features**

* Added the ability to skip corrupt archives rather than failing the STACS run.
  * This must be explicitly enabled using the `--skip-unprocessable` flag.
  * A warning message will be produced for each 'skipped' archive.

### 🍩 **Improvements**

* Added additional debug level logging related to file enumeration.
  * This output is only provided when run with the `--debug` flag.

### 🐛 **Bug Fixes**

* N/A