### PR TITLE
[0.4.4] Load ignore-list from scan directory by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ LABEL org.opencontainers.image.version=$VERSION
 WORKDIR /opt/stacs
 COPY requirements.txt setup.py setup.cfg ./
 COPY stacs ./stacs
+COPY wrapper/stacs-scan /usr/bin
+
 RUN apk add --no-cache git gcc musl-dev libarchive-dev libarchive && \
     pip install --no-cache-dir .
 
@@ -34,9 +36,4 @@ VOLUME /mnt/stacs/cache
 RUN apk del --purge gcc musl-dev git
 
 # Default to running stacs with the volume mounts.
-ENTRYPOINT ["stacs"]
-CMD [ \
-    "--rule-pack", "/mnt/stacs/rules/credential.json", \
-    "--cache-directory", "/mnt/stacs/cache", \
-    "/mnt/stacs/input" \
-]
+ENTRYPOINT ["stacs-scan"]

--- a/stacs/scan/__about__.py
+++ b/stacs/scan/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs"
 __summary__ = "Static Token And Credential Scanner."
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs/"
 __license__ = "BSD-3-Clause"

--- a/stacs/scan/model/ignore_list.py
+++ b/stacs/scan/model/ignore_list.py
@@ -57,14 +57,6 @@ class Entry(BaseModel, extra=Extra.forbid):
 
         return value
 
-    @validator("offset", "references", always=True)
-    def offset_and_references_requires_module(cls, value, values):
-        """Ensure that if offset or references is set, module is as well."""
-        if not values.get("module"):
-            raise IgnoreListException("Module must be set for this type of ignore.")
-
-        return value
-
     @validator("offset", always=True)
     def offset_and_refernces_both_set(cls, value, values):
         if value and len(values.get("references")) > 0:

--- a/wrapper/stacs-scan
+++ b/wrapper/stacs-scan
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# This wrapper is used to determine whether a stacs ignore is present in the scan
+# directory.
+#
+
+SCAN_DIR="/mnt/stacs/input"
+
+# If additional arguments are provided, use them instead of defaults.
+if [ "$#" -gt 0 ]; then
+    stacs "$@"
+else
+    # Use an ignore list, if present.
+    if [ -e "${SCAN_DIR}/stacs.ignore.json" ]; then
+        stacs \
+            --rule-pack /mnt/stacs/rules/credential.json \
+            --cache-directory /mnt/stacs/cache \
+            --ignore-list "${SCAN_DIR}/stacs.ignore.json" \
+            "${SCAN_DIR}/"
+    else
+        stacs \
+            --rule-pack /mnt/stacs/rules/credential.json \
+            --cache-directory /mnt/stacs/cache \
+            "${SCAN_DIR}/"
+    fi
+fi


### PR DESCRIPTION
## Overview

This pull-request makes a change to the way the STACS container runs. The container entrypoint is now a script which performs a check to see whether the scan directory contains an ignore list. If so, this will be loaded automatically.

This PR also removes an unnecessary validator from the ignore list model.

### 🛠️ **New Features**

* The STACS container now attempts to automatically load a `stacs.ignore.json` from the scan directory.

### 🍩 **Improvements**

* Clean-up of Pydantic validator for the ignore list model.

### 🐛 **Bug Fixes**

* N/A