### PR TITLE
Allow updating existing containers with new rules.

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,53 @@
+name: Update
+
+on:
+  workflow_dispatch:
+    release:
+      description: The tagged release version to rebuild with the latest rules.
+      default: 0.0.0
+      required: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: refs/tags/${{ github.event.inputs.release }}
+
+      - name: Configure Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libarchive13 libarchive-dev
+
+      - name: Extract version
+        run: |
+          git clone https://www.github.com/stacscan/stacs-rules.git /tmp/stacs-rules
+          pushd /tmp/stacs-rules
+          RULES_VERSION="$(git rev-parse --short HEAD)"
+          popd
+          pip install .
+          STACS_VERSION="$(python -c 'from stacs.scan.__about__ import __version__ ; print(__version__, end="")')"
+          echo "IMAGE_VERSION=${STACS_VERSION}-r${RULES_VERSION}" >> "${GITHUB_ENV}"
+          echo "STACS_VERSION=${STACS_VERSION}" >> "${GITHUB_ENV}"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: stacscan/stacs:latest,stacscan/stacs:${{ env.IMAGE_VERSION }}
+          build-args: |
+            VERSION=${{ env.IMAGE_VERSION }}


### PR DESCRIPTION
## Overview

This pull-request allows a tagged version of STACS to be re-released with a newer ruleset.

To ensure that only rules are updated, and no code changes are included in the update, this manual action forces the use of a tagged / released version to be specified.

This is a release management change.