### PR TITLE
[0.4.5] Allow thread count to be specified, and support for Python 3.8

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,25 +11,43 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Configure Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
       - name: Install Dependencies
         run: |
           sudo apt update
           sudo apt install -y libarchive13 libarchive-dev
+
+      - name: Configure Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
 
       - name: Install Tox
         run: |
           python -m pip install --upgrade pip wheel setuptools
           pip install tox
 
-      - name: Run Linter
+      - name: Run Linter (3.9)
         run: |
-          tox -e lint
+          tox -e py39-lint
 
-      - name: Run Tests
+      - name: Run Tests (3.9)
         run: |
-          tox -e test
+          tox -e py39-test
+
+      - name: Configure Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Tox
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          pip install tox
+
+      - name: Run Linter (3.8)
+        run: |
+          tox -e py38-lint
+
+      - name: Run Tests (3.8)
+        run: |
+          tox -e py38-test

--- a/.github/workflows/publish_to_testing.yml
+++ b/.github/workflows/publish_to_testing.yml
@@ -1,0 +1,45 @@
+name: Publish to Testing
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: The commit ref to build and release to PyPI testing.
+        required: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.release }}
+
+      - name: Configure Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libarchive13 libarchive-dev
+
+      # This is rather unpleasant and the package versioning should be adjusted to
+      # allow snapshot build numbers to be injected via setuptools, etc.
+      - name: Set RC version
+        run: |
+          sed -iE 's/^__version__(.*)?"$/__version__\1-rc.${{ github.run_id }}"/' \
+            stacs/scan/__about__.py
+
+      - name: Build Python package
+        run: |
+          python -m pip install --upgrade pip wheel setuptools build
+          python -m build --sdist --config-setting --outdir dist/ .
+
+      - name: Publish Python package
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TESTING_TOKEN }}
+          repository_url: "https://test.pypi.org/legacy/"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,10 +2,11 @@ name: Update
 
 on:
   workflow_dispatch:
-    release:
-      description: The tagged release version to rebuild with the latest rules.
-      default: 0.0.0
-      required: true
+    inputs:
+      release:
+        description: The tagged release version to rebuild with the latest rules.
+        default: 0.0.0
+        required: true
 
 jobs:
   update:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [metadata]
 name = stacs
 classifiers = 
-    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.8
     Natural Language :: English
 
 [flake8]
 max-line-length = 88
 
 [options]
-python_requires = >= 3.9
+python_requires = >= 3.8
 
 [options.entry_points]
 console_scripts =

--- a/stacs/scan/__about__.py
+++ b/stacs/scan/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs"
 __summary__ = "Static Token And Credential Scanner."
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs/"
 __license__ = "BSD-3-Clause"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = lint, test
+envlist = {py38,py39}-lint, {py38,py39}-test
 
 [testenv]
 deps =
@@ -8,9 +8,6 @@ deps =
     pytest
     pytest-cov
     -rrequirements.txt
-
-[testenv:lint]
-commands = flake8 stacs/ tests/
-
-[testenv:test]
-commands = pytest --cov=stacs tests/
+commands =
+    lint: flake8 stacs/ tests/
+    test: pytest --cov=stacs tests/


### PR DESCRIPTION
## Overview

This pull-request makes a few convenience changes to STACS.

### 🛠️ **New Features**

* Specification of the number of threads is now possible via `--threads` (defaults to: `10`)

### 🍩 **Improvements**

* Version constraint has been relaxed to allow Python 3.8 (per request #16).
* Cache directories are attempted to be cleaned-up after run.
* Cache directories now have a timestamp appended to avoid collisions if previous run failed.
* Minor changes to release management process to allow easier rebuilds of containers with new rules.

### 🐛 **Bug Fixes**

* N/A