### PR TITLE
[0.4.6] Performance improvements, and convenience features.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM python:3.9-alpine
 # Allow build-time specification of version.
 ARG VERSION
 
+# Allow runtime tuning.
+ENV STACS_SKIP_UNPROCESSABLE=0
+ENV STACS_THREADS=10
+ENV STACS_DEBUG=0
+
 # Keep things friendly.
 LABEL org.opencontainers.image.title="STACS"
 LABEL org.opencontainers.image.description="Static Token And Credential Scanner"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile
 #
-click==8.0.1
+click==8.1.2
     # via -r requirements.in
-pydantic==1.8.2
+pydantic==1.9.0
     # via -r requirements.in
 python-libarchive==4.0.1.post1
     # via -r requirements.in
-typing-extensions==3.10.0.0
+typing-extensions==4.1.1
     # via pydantic
-yara-python==4.1.0
+yara-python==4.2.0
     # via -r requirements.in

--- a/stacs/scan/__about__.py
+++ b/stacs/scan/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs"
 __summary__ = "Static Token And Credential Scanner."
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs/"
 __license__ = "BSD-3-Clause"

--- a/stacs/scan/constants.py
+++ b/stacs/scan/constants.py
@@ -15,3 +15,6 @@ CACHE_DIRECTORY = "/tmp"
 # Define the character to use when constructed paths to findings which are inside of
 # archives.
 ARCHIVE_FILE_SEPARATOR = "!"
+
+# Define an exit code to use when there are unsuppressed findings.
+EXIT_CODE_UNSUPPRESSED = 100

--- a/stacs/scan/entrypoint/cli.py
+++ b/stacs/scan/entrypoint/cli.py
@@ -154,3 +154,11 @@ def main(
     # TODO: Add file output as an option.
     logger.info(f"Found {len(findings)} findings")
     print(sarif)
+
+    # Exit with a status which reflects that unsuppressed findings were encountered if
+    # required.
+    for finding in findings:
+        if not finding.ignore:
+            sys.exit(stacs.scan.constants.EXIT_CODE_FINDING)
+
+    sys.exit(0)

--- a/stacs/scan/entrypoint/cli.py
+++ b/stacs/scan/entrypoint/cli.py
@@ -58,7 +58,7 @@ def unlink_error(function: Callable, path: str, exc_info: TracebackType):
     help="The path to use as a cache - used when unpacking archives.",
     default=stacs.scan.constants.CACHE_DIRECTORY,
 )
-@click.argument("path", "paths", nargs=-1)
+@click.argument("paths", nargs=-1, required=True)
 def main(
     debug: bool,
     threads: int,
@@ -159,6 +159,6 @@ def main(
     # required.
     for finding in findings:
         if not finding.ignore:
-            sys.exit(stacs.scan.constants.EXIT_CODE_FINDING)
+            sys.exit(stacs.scan.constants.EXIT_CODE_UNSUPPRESSED)
 
     sys.exit(0)

--- a/stacs/scan/scanner/rules.py
+++ b/stacs/scan/scanner/rules.py
@@ -87,22 +87,26 @@ def generate_sample(target: manifest.Entry, offset: int, size: int) -> finding.S
     except OSError as err:
         raise FileAccessException(err)
 
-    if binary:
-        return finding.Sample(
-            window=WINDOW_SIZE,
-            before=base64.b64encode(before),
-            after=base64.b64encode(after),
-            finding=base64.b64encode(entry),
-            binary=binary,
-        )
-    else:
-        return finding.Sample(
-            window=WINDOW_SIZE,
-            before=str(before, "utf-8"),
-            after=str(after, "utf-8"),
-            finding=str(entry, "utf-8"),
-            binary=binary,
-        )
+    if not binary:
+        try:
+            return finding.Sample(
+                window=WINDOW_SIZE,
+                before=str(before, "utf-8"),
+                after=str(after, "utf-8"),
+                finding=str(entry, "utf-8"),
+                binary=binary,
+            )
+        except UnicodeDecodeError:
+            # Fall through and return a base64 encoded sample.
+            pass
+
+    return finding.Sample(
+        window=WINDOW_SIZE,
+        before=base64.b64encode(before),
+        after=base64.b64encode(after),
+        finding=base64.b64encode(entry),
+        binary=binary,
+    )
 
 
 def generate_location(target: manifest.Entry, offset: int) -> finding.Location:

--- a/wrapper/stacs-scan
+++ b/wrapper/stacs-scan
@@ -6,6 +6,21 @@
 
 SCAN_DIR="/mnt/stacs/input"
 
+# Define additional flags to pass.
+STACS_FLAGS=""
+
+if [ ${STACS_SKIP_UNPROCESSABLE:-0} -ne 0 ]; then
+    STACS_FLAGS="${STACS_FLAGS} --skip-unprocessable"
+fi
+
+if [ ${STACS_THREADS:-10} -ne 10 ]; then
+    STACS_FLAGS="${STACS_FLAGS} --threads ${STACS_THREADS}"
+fi
+
+if [ ${STACS_DEBUG:-0} -ne 0 ]; then
+    STACS_FLAGS="${STACS_FLAGS} --debug"
+fi
+
 # If additional arguments are provided, use them instead of defaults.
 if [ "$#" -gt 0 ]; then
     stacs "$@"
@@ -16,11 +31,13 @@ else
             --rule-pack /mnt/stacs/rules/credential.json \
             --cache-directory /mnt/stacs/cache \
             --ignore-list "${SCAN_DIR}/stacs.ignore.json" \
+            ${STACS_FLAGS} \
             "${SCAN_DIR}/"
     else
         stacs \
             --rule-pack /mnt/stacs/rules/credential.json \
             --cache-directory /mnt/stacs/cache \
+            ${STACS_FLAGS} \
             "${SCAN_DIR}/"
     fi
 fi


### PR DESCRIPTION
## Overview

This pull-request makes a number of convenience and performance improvements to STACS.

### 🛠️ **New Features**

* Exit status is now non-zero if there are unsuppressed findings.
    * This was based on the suggestion as part of #19.
    * Exit status is now `100` when there are unsuppressed findings.
* STACS supports multiple paths to scan.
    * This was based on the suggestion as part of #18.
    * Mutiple paths can now be passed directly to STACS at runtime, and they will all be scanned. 
* When running a container, specification of thread count, whether to enable debug, and whether to skip unprocessable archives can be controlled by environment variables
    * `STACS_SKIP_UNPROCESSABLE`
    * `STACS_THREADS`
    * `STACS_DEBUG`

### 🍩 **Improvements**

* **SIGNIFICANT** performance improvements due to optimisation of rules.
    * In testing this has seen scan runtime improvements of up to 8x in some cases.
* Dependencies have been updated.

### 🐛 **Bug Fixes**

* Resolved a minor edge-case where non UTF-8 characters would break sample generation.
    * Unprocessable samples will now be base64 encoded - the same way that binary data is handled. 