### PR TITLE
[0.4.9] Add parent MD5 to enumerated files.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ setup(
     },
     install_requires=[
         "click==8.1.3",
-        "yara-python==4.2.0",
-        "pydantic==1.9.1",
+        "yara-python==4.2.3",
+        "pydantic==1.10.2",
         "colorama==0.4.5",
     ],
 )

--- a/stacs/scan/__about__.py
+++ b/stacs/scan/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs"
 __summary__ = "Static Token And Credential Scanner."
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs/"
 __license__ = "BSD-3-Clause"

--- a/stacs/scan/loader/filepath.py
+++ b/stacs/scan/loader/filepath.py
@@ -19,7 +19,7 @@ from stacs.scan.model.manifest import Entry
 logger = logging.getLogger(__name__)
 
 
-def metadata(filepath: str, overlay: str = None) -> Entry:
+def metadata(filepath: str, overlay: str = None, parent: str = None) -> Entry:
     """Generates a hash and determines the mimetype of the input file."""
     md5 = hashlib.md5()
     mime = None
@@ -41,6 +41,7 @@ def metadata(filepath: str, overlay: str = None) -> Entry:
         md5=md5.hexdigest(),
         mime=mime,
         overlay=overlay,
+        parent=parent,
     )
 
 
@@ -159,7 +160,9 @@ def finder(
                     )
 
                     # Submit back to the pool for processing.
-                    submission = pool.submit(metadata, file, overlay=overlay)
+                    submission = pool.submit(
+                        metadata, file, overlay=overlay, parent=result.md5
+                    )
                     futures[submission] = file
 
             if complete == 0:

--- a/stacs/scan/model/manifest.py
+++ b/stacs/scan/model/manifest.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: BSD-3-Clause
 """
 
 from typing import List
+
 from pydantic import BaseModel, Extra, Field
 
 
@@ -24,6 +25,10 @@ class Entry(BaseModel, extra=Extra.forbid):
     md5: str = Field(
         None,
         title="The MD5 sum of the file.",
+    )
+    parent: str = Field(
+        None,
+        title="The MD5 sum of the file's parent.",
     )
     mime: str = Field(
         None,


### PR DESCRIPTION
## Overview

This pull-request adds the parent MD5 sum to the internal `manifest.Entry` model. 

### 🛠️ **New Features**

* Add parent MD5 of nested archive members to internal entries model. 

### 🍩 **Improvements**

* Dependency updates.

### 🐛 **Bug Fixes**

* N/A