### PR TITLE
[0.4.11] Add Zlib. Weighted archive detection. Fix DMG chunk issues.

### DIFF
--- a/stacs/scan/__about__.py
+++ b/stacs/scan/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs"
 __summary__ = "Static Token And Credential Scanner."
-__version__ = "0.4.10"
+__version__ = "0.4.11"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs/"
 __license__ = "BSD-3-Clause"

--- a/stacs/scan/loader/archive.py
+++ b/stacs/scan/loader/archive.py
@@ -344,7 +344,10 @@ def get_mimetype(chunk: bytes, start: bool) -> List[Tuple[int, str]]:
         offset = options["offset"]
         magic = options["magic"]
 
-        # If looking at the end of the file, skip all non-negative offsets.
+        # If looking at the last chunk, only use negative offsets. This is to prevent
+        # false positives as position 0 in the last chunk is actually N bytes into the
+        # file. This is especially problematic for formats with short magic numbers,
+        # such as zlib.
         if not start and offset >= 0:
             continue
 

--- a/stacs/scan/loader/archive.py
+++ b/stacs/scan/loader/archive.py
@@ -88,9 +88,9 @@ def gzip_handler(filepath: str, directory: str) -> None:
     """Attempts to extract the provided gzip archive."""
     output = ".".join(os.path.basename(filepath).split(".")[:-1])
 
-    # Ensure that files with a proceeding dot are properly handled.
+    # No dots? Just use the name as is.
     if len(output) < 1:
-        output = os.path.basename(filepath).lstrip(".")
+        output = filepath
 
     # Although gzip files cannot contain more than one file, we'll still spool into
     # a subdirectory under the cache for consistency.
@@ -117,6 +117,10 @@ def bzip2_handler(filepath: str, directory: str) -> None:
     """Attempts to extract the provided bzip2 archive."""
     output = ".".join(os.path.basename(filepath).split(".")[:-1])
 
+    # No dots? Just use the name as is.
+    if len(output) < 1:
+        output = filepath
+
     # Like gzip, bzip2 cannot support more than a single file. Again, we'll spool into
     # a subdirectory for consistency.
     try:
@@ -141,6 +145,10 @@ def bzip2_handler(filepath: str, directory: str) -> None:
 def zstd_handler(filepath: str, directory: str) -> None:
     """Attempts to extract the provided zstd archive."""
     output = ".".join(os.path.basename(filepath).split(".")[:-1])
+
+    # No dots? Just use the name as is.
+    if len(output) < 1:
+        output = filepath
 
     # zstd does not appear to provide a native mechanism to compress multiple files,
     # and recommend 'to combine zstd with tar'.
@@ -167,9 +175,9 @@ def lzma_handler(filepath: str, directory: str) -> None:
     """Attempts to extract the provided xz / lzma archive."""
     output = ".".join(os.path.basename(filepath).split(".")[:-1])
 
-    # Ensure that files with a proceeding dot are properly handled.
+    # No dots? Just use the name as is.
     if len(output) < 1:
-        output = os.path.basename(filepath).lstrip(".")
+        output = filepath
 
     # Although xz files cannot contain more than one file, we'll still spool into
     # a subdirectory under the cache for consistency.
@@ -194,9 +202,9 @@ def zlib_handler(filepath: str, directory: str) -> None:
     """Attempts to extract the provided zlib archive."""
     output = ".".join(os.path.basename(filepath).split(".")[:-1])
 
-    # Ensure that files with a proceeding dot are properly handled.
+    # No dots? Just use the name as is.
     if len(output) < 1:
-        output = os.path.basename(filepath).lstrip(".")
+        output = filepath
 
     try:
         os.mkdir(directory, mode=0o700)
@@ -210,8 +218,6 @@ def zlib_handler(filepath: str, directory: str) -> None:
 
         with open(filepath, "rb") as fin:
             with open(os.path.join(directory, output), "wb") as fout:
-
-                # Once again, read in chunks.
                 while compressed := fin.read(CHUNK_SIZE):
                     fout.write(decompressor.decompress(compressed))
     except zlib.error as err:

--- a/stacs/scan/loader/archive.py
+++ b/stacs/scan/loader/archive.py
@@ -12,6 +12,8 @@ import os
 import shutil
 import tarfile
 import zipfile
+import zlib
+from typing import List, Tuple
 
 import zstandard
 from stacs.native import archive
@@ -188,6 +190,36 @@ def lzma_handler(filepath: str, directory: str) -> None:
         )
 
 
+def zlib_handler(filepath: str, directory: str) -> None:
+    """Attempts to extract the provided zlib archive."""
+    output = ".".join(os.path.basename(filepath).split(".")[:-1])
+
+    # Ensure that files with a proceeding dot are properly handled.
+    if len(output) < 1:
+        output = os.path.basename(filepath).lstrip(".")
+
+    try:
+        os.mkdir(directory, mode=0o700)
+    except OSError as err:
+        raise FileAccessException(
+            f"Unable to create unpack directory at {directory}: {err}"
+        )
+
+    try:
+        decompressor = zlib.decompressobj(wbits=zlib.MAX_WBITS)
+
+        with open(filepath, "rb") as fin:
+            with open(os.path.join(directory, output), "wb") as fout:
+
+                # Once again, read in chunks.
+                while compressed := fin.read(CHUNK_SIZE):
+                    fout.write(decompressor.decompress(compressed))
+    except zlib.error as err:
+        raise InvalidFileException(
+            f"Unable to extract archive {filepath} to {output}: {err}"
+        )
+
+
 def xar_handler(filepath: str, directory: str) -> None:
     """Attempts to extract the provided XAR archive."""
     try:
@@ -287,22 +319,28 @@ def libarchive_handler(filepath: str, directory: str) -> None:
         )
 
 
-def get_mimetype(chunk: bytes) -> str:
+def get_mimetype(chunk: bytes) -> List[Tuple[int, str]]:
     """Attempts to locate the appropriate handler for a given file.
 
     This may fail if the required "magic" is at an offset greater than the CHUNK_SIZE.
     However, currently this is not an issue, but may need to be revisited later as more
     archive types are supported.
+
+    Returns a list of weights and MIME types as a tuple. This weight is specified by
+    handlers and is used to allow "container" formats, which may contain multiple other
+    files of various matching types, to "win" the match - due to a higher weight.
     """
+
     for name, options in MIME_TYPE_HANDLERS.items():
         offset = options["offset"]
         magic = options["magic"]
 
-        for candidate in magic:
-            if chunk[offset : (offset + len(candidate))] == candidate:  # noqa: E203
-                return name
+        # TODO: How to handle multiple matches in the same chunk? Is this this likely?
+        for format in magic:
+            if chunk[offset : (offset + len(format))] == format:  # noqa: E203
+                return (options["weight"], name)
 
-    return None
+    return (0, None)
 
 
 # Define all supported archives and their handlers. As we currently only support a small
@@ -312,6 +350,7 @@ def get_mimetype(chunk: bytes) -> str:
 # unpacking, as we're only looking for a small number of types.
 MIME_TYPE_HANDLERS = {
     "application/x-tar": {
+        "weight": 1,
         "offset": 257,
         "magic": [
             bytearray([0x75, 0x73, 0x74, 0x61, 0x72]),
@@ -319,6 +358,7 @@ MIME_TYPE_HANDLERS = {
         "handler": tar_handler,
     },
     "application/gzip": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0x1F, 0x8B]),
@@ -326,6 +366,7 @@ MIME_TYPE_HANDLERS = {
         "handler": gzip_handler,
     },
     "application/x-bzip2": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0x42, 0x5A, 0x68]),
@@ -333,6 +374,7 @@ MIME_TYPE_HANDLERS = {
         "handler": bzip2_handler,
     },
     "application/zip": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0x50, 0x4B, 0x03, 0x04]),
@@ -341,7 +383,19 @@ MIME_TYPE_HANDLERS = {
         ],
         "handler": zip_handler,
     },
+    "application/zlib": {
+        "weight": 1,
+        "offset": 0,
+        "magic": [
+            bytearray([0x78, 0x01]),
+            bytearray([0x78, 0x5E]),
+            bytearray([0x78, 0x9C]),
+            bytearray([0x78, 0xDA]),
+        ],
+        "handler": zlib_handler,
+    },
     "application/x-xz": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00]),
@@ -349,6 +403,7 @@ MIME_TYPE_HANDLERS = {
         "handler": lzma_handler,
     },
     "application/x-rpm": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0xED, 0xAB, 0xEE, 0xDB]),
@@ -356,6 +411,7 @@ MIME_TYPE_HANDLERS = {
         "handler": libarchive_handler,
     },
     "application/x-iso9660-image": {
+        "weight": 1,
         "offset": 0x8001,
         "magic": [
             bytearray([0x43, 0x44, 0x30, 0x30, 0x31]),
@@ -363,6 +419,7 @@ MIME_TYPE_HANDLERS = {
         "handler": libarchive_handler,
     },
     "application/x-7z-compressed": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C]),
@@ -370,6 +427,7 @@ MIME_TYPE_HANDLERS = {
         "handler": libarchive_handler,
     },
     "application/x-cpio": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0xC7, 0x71]),  # 070707 in octal (Little Endian).
@@ -381,6 +439,7 @@ MIME_TYPE_HANDLERS = {
         "handler": libarchive_handler,
     },
     "application/x-xar": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0x78, 0x61, 0x72, 0x21]),
@@ -388,6 +447,7 @@ MIME_TYPE_HANDLERS = {
         "handler": xar_handler,
     },
     "application/vnd.ms-cab-compressed": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0x4D, 0x53, 0x43, 0x46]),
@@ -395,6 +455,7 @@ MIME_TYPE_HANDLERS = {
         "handler": libarchive_handler,
     },
     "application/x-archive": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0x21, 0x3C, 0x61, 0x72, 0x63, 0x68, 0x3E]),
@@ -402,6 +463,7 @@ MIME_TYPE_HANDLERS = {
         "handler": libarchive_handler,
     },
     "application/vnd.rar": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07]),
@@ -409,6 +471,7 @@ MIME_TYPE_HANDLERS = {
         "handler": libarchive_handler,
     },
     "application/zstd": {
+        "weight": 1,
         "offset": 0,
         "magic": [
             bytearray([0x28, 0xB5, 0x2F, 0xFD]),
@@ -416,6 +479,7 @@ MIME_TYPE_HANDLERS = {
         "handler": zstd_handler,
     },
     "application/x-apple-diskimage": {
+        "weight": 2,  # "container" formats are weighted higher.
         "offset": -512,
         "magic": [
             bytearray([0x6B, 0x6F, 0x6C, 0x79]),

--- a/stacs/scan/loader/filepath.py
+++ b/stacs/scan/loader/filepath.py
@@ -34,7 +34,8 @@ def metadata(filepath: str, overlay: str = None, parent: str = None) -> Entry:
                 # Attempt to determine the mime-type using the first and last chunk.
                 # Note: This may need to change further in future.
                 if (not mime and fin.tell() <= CHUNK_SIZE) or len(chunk) < CHUNK_SIZE:
-                    (score, candidate) = archive.get_mimetype(chunk)
+                    start = False if len(chunk) < CHUNK_SIZE else True
+                    (score, candidate) = archive.get_mimetype(chunk, start)
 
                     # Swap the winner if the score is higher.
                     if score > winner:

--- a/stacs/scan/loader/format/dmg.py
+++ b/stacs/scan/loader/format/dmg.py
@@ -2,6 +2,7 @@
 
 SPDX-License-Identifier: BSD-3-Clause
 """
+
 import os
 import plistlib
 import struct
@@ -184,7 +185,7 @@ class DMG:
                     continue
 
                 try:
-                    with open(output, "wb") as fout, open(self.archive, "rb") as fin:
+                    with open(output, "ab") as fout, open(self.archive, "rb") as fin:
                         # 0x00000000 - Zero Fill.
                         if chunk.type == 0x00000000:
                             for _ in range(0, chunk_chunk):

--- a/stacs/scan/loader/format/dmg.py
+++ b/stacs/scan/loader/format/dmg.py
@@ -13,7 +13,6 @@ from collections import namedtuple
 from typing import List
 
 from pydantic import BaseModel, Extra, Field
-from stacs.scan.constants import CHUNK_SIZE
 from stacs.scan.exceptions import FileAccessException, InvalidFileException
 
 # Structures names and geometry are via "Demystifying the DMG File Format"

--- a/stacs/scan/loader/format/dmg.py
+++ b/stacs/scan/loader/format/dmg.py
@@ -3,9 +3,12 @@
 SPDX-License-Identifier: BSD-3-Clause
 """
 
+import bz2
+import lzma
 import os
 import plistlib
 import struct
+import zlib
 from collections import namedtuple
 from typing import List
 
@@ -174,37 +177,35 @@ class DMG:
             output = os.path.join(destination, f"{parent}.{idx}.blob")
 
             for chunk in block.chunks:
-                # We have our own chunk size used to keep memory low. So this oddly
-                # named chunk "chunk" is the DMG chunk split into chunks that meet our
-                # size requirements.
-                bytes_read = 0
-                chunk_chunk = int(chunk.compressed_length / CHUNK_SIZE)
-
                 # Skip Ignored, Comment, and Last blocks (respectively).
                 if chunk.type in [0x00000002, 0x7FFFFFFE, 0xFFFFFFFF]:
                     continue
 
                 try:
-                    with open(output, "ab") as fout, open(self.archive, "rb") as fin:
-                        # 0x00000000 - Zero Fill.
-                        if chunk.type == 0x00000000:
-                            for _ in range(0, chunk_chunk):
-                                fout.write("\x00" * CHUNK_SIZE)
-                                bytes_read += CHUNK_SIZE
-
-                            # Last partial chunk.
-                            fout.write(b"\x00" * (chunk.compressed_length - bytes_read))
-                            continue
-
-                        # For all other types, write to disk, as STACS may be able to
-                        # decompress or handle these formats natively.
+                    with open(self.archive, "rb") as fin, open(output, "ab") as fout:
                         fin.seek(chunk.compressed_offset)
 
-                        for _ in range(0, chunk_chunk):
-                            fout.write(fin.read(CHUNK_SIZE))
-                            bytes_read += CHUNK_SIZE
+                        # 0x80000005 - Zlib.
+                        if chunk.type == 0x80000005:
+                            fout.write(
+                                zlib.decompress(fin.read(chunk.compressed_length))
+                            )
 
-                        # Read the last partial chunk.
-                        fout.write(fin.read(chunk.compressed_length - bytes_read))
-                except OSError as err:
+                        # 0x80000005 - BZ2.
+                        if chunk.type == 0x80000006:
+                            fout.write(
+                                bz2.decompress(fin.read(chunk.compressed_length))
+                            )
+
+                        # 0x80000005 - LZMA.
+                        if chunk.type == 0x80000008:
+                            fout.write(
+                                lzma.decompress(fin.read(chunk.compressed_length))
+                            )
+
+                        # 0x00000000 - Zero Fill.
+                        if chunk.type == 0x00000000:
+                            fout.write(b"\x00" * chunk.compressed_length)
+                            continue
+                except (OSError, lzma.LZMAError, ValueError) as err:
                     raise InvalidFileException(err)

--- a/stacs/scan/loader/format/dmg.py
+++ b/stacs/scan/loader/format/dmg.py
@@ -198,6 +198,8 @@ class DMG:
 
                         # For all other types, write to disk, as STACS may be able to
                         # decompress or handle these formats natively.
+                        fin.seek(chunk.compressed_offset)
+
                         for _ in range(0, chunk_chunk):
                             fout.write(fin.read(CHUNK_SIZE))
                             bytes_read += CHUNK_SIZE


### PR DESCRIPTION
## Overview

This pull-request adds support for zlib unpacking, weighted archive detection, and resolves a trivial bug in the DMG implementation which lead to incomplete extraction of blobs from DMGs.

### 🛠️ **New Features**

* Zlib support

### 🍩 **Improvements**

* Handle `lzma`, `zlib`, and `bz2` compressed chunks in DMG reader.
* Weighted archive detection.
  * Allows preferencing "container" formats when blobs contain multiple detected formats.

### 🐛 **Bug Fixes**

* Chunking issue in DMG reader.